### PR TITLE
Fix Precision Decimal in DataTransformer

### DIFF
--- a/Form/DataTransformer/MoneyToArrayTransformer.php
+++ b/Form/DataTransformer/MoneyToArrayTransformer.php
@@ -21,7 +21,7 @@ class MoneyToArrayTransformer implements DataTransformerInterface
     public function __construct($decimals = 2)
     {
         $this->decimals = (int)$decimals;
-        $this->sfTransformer = new MoneyToLocalizedStringTransformer(null, null, null, pow(10, $this->decimals));
+        $this->sfTransformer = new MoneyToLocalizedStringTransformer($decimals, null, null, pow(10, $this->decimals));
     }
 
     /**


### PR DESCRIPTION
add $decimals as the first parameter, because the Symfony Transformer used in MoneyToLocalizedStringTransformer uses a precision. and this precision is lost by letting the first param on null
